### PR TITLE
Add DISABLE_REGISTRATION environment variable to hide registration UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Models can be configured for specific zoom levels (8-21) to optimize performance
 - `DB_NAME` - Database name
 - `DB_USER` - Database user
 - `DB_PASSWORD` - Database password
+- `DISABLE_REGISTRATION` - Set to `true` to disable new user registration (default: false)
 
 ## Web Interface
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - DB_USER=osmsat
       - DB_PASSWORD=osmsat123
       - JWT_SECRET=your-production-secret-key-here
+      # - DISABLE_REGISTRATION=true  # Uncomment to disable new user registration
     volumes:
       - ./uploads:/app/uploads
       - ./public:/app/public

--- a/public/index.html
+++ b/public/index.html
@@ -204,15 +204,18 @@
     <script>
         let authToken = localStorage.getItem('authToken');
         let currentUser = null;
+        let registrationEnabled = true;
 
         document.addEventListener('DOMContentLoaded', function() {
             console.log('DOM loaded, setting up event handlers');
             
-            if (authToken) {
-                fetchCurrentUser().then(() => {
-                    showLoggedInState();
-                });
-            }
+            fetchRegistrationStatus().then(() => {
+                if (authToken) {
+                    fetchCurrentUser().then(() => {
+                        showLoggedInState();
+                    });
+                }
+            });
 
             const showLoginBtn = document.getElementById('showLogin');
             const showRegisterBtn = document.getElementById('showRegister');
@@ -231,6 +234,10 @@
             if (showRegisterBtn) {
                 showRegisterBtn.onclick = function() {
                     console.log('Register button clicked');
+                    if (!registrationEnabled) {
+                        alert('Registration is currently disabled');
+                        return;
+                    }
                     document.getElementById('registerForm').classList.add('active');
                     document.getElementById('loginForm').classList.remove('active');
                 };
@@ -271,10 +278,10 @@
 
         function showLoggedOutState() {
             document.getElementById('showLogin').classList.remove('hidden');
-            document.getElementById('showRegister').classList.remove('hidden');
             document.getElementById('userInfo').classList.add('hidden');
             document.getElementById('logout').classList.add('hidden');
             document.getElementById('uploadSection').classList.add('hidden');
+            updateRegistrationUI();
         }
 
         function setupFileDropZone() {
@@ -665,6 +672,35 @@
                 authToken = null;
                 currentUser = null;
                 showLoggedOutState();
+            }
+        }
+
+        async function fetchRegistrationStatus() {
+            try {
+                const response = await fetch('/api/auth/registration-enabled');
+                if (response.ok) {
+                    const data = await response.json();
+                    registrationEnabled = data.enabled;
+                    updateRegistrationUI();
+                } else {
+                    console.error('Failed to fetch registration status');
+                    registrationEnabled = true; // Default to enabled
+                }
+            } catch (err) {
+                console.error('Failed to fetch registration status:', err);
+                registrationEnabled = true; // Default to enabled
+            }
+        }
+
+        function updateRegistrationUI() {
+            const showRegisterBtn = document.getElementById('showRegister');
+            const registerForm = document.getElementById('registerForm');
+            
+            if (registrationEnabled) {
+                showRegisterBtn.classList.remove('hidden');
+            } else {
+                showRegisterBtn.classList.add('hidden');
+                registerForm.classList.remove('active');
             }
         }
 

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -6,6 +6,10 @@ const { pool } = require('../database');
 const router = express.Router();
 
 router.post('/register', async (req, res) => {
+  if (process.env.DISABLE_REGISTRATION === 'true') {
+    return res.status(403).json({ error: 'Registration is disabled' });
+  }
+
   const { username, email, password } = req.body;
 
   if (!username || !email || !password) {

--- a/src/server.js
+++ b/src/server.js
@@ -40,6 +40,11 @@ app.get('/health', (req, res) => {
   res.json({ status: 'OK', timestamp: new Date().toISOString() });
 });
 
+app.get('/api/auth/registration-enabled', (req, res) => {
+  const registrationEnabled = process.env.DISABLE_REGISTRATION !== 'true';
+  res.json({ enabled: registrationEnabled });
+});
+
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, '../public/index.html'));
 });


### PR DESCRIPTION
## Summary
- Add support for `DISABLE_REGISTRATION` environment variable
- When set to `true`, completely removes registration functionality from UI
- Backend returns 403 for registration attempts when disabled
- Maintains existing authentication for current users

## Changes Made
- **Backend**: Added `/api/auth/registration-enabled` endpoint to check status
- **Backend**: Modified `/api/auth/register` to return 403 when disabled
- **Frontend**: Added conditional UI rendering based on registration status
- **Frontend**: Hide register button and form when registration disabled
- **Documentation**: Updated README.md with environment variable details
- **Docker**: Added commented example in docker-compose.yml

## Test Results
✅ Registration enabled by default: `/api/auth/registration-enabled` returns `{"enabled":true}`
✅ Registration disabled when `DISABLE_REGISTRATION=true`: returns `{"enabled":false}`
✅ Registration endpoint returns 403 when disabled: `{"error":"Registration is disabled"}`
✅ Frontend hides registration UI when disabled
✅ Login functionality unaffected

## Fixes
Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)