### PR TITLE
Remove false statement about Zoom Level.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,6 @@ version: "1.0.0"
 date: "2025-01-15"
 ```
 
-### Zoom Level Support
-Models can be configured for specific zoom levels (8-21) to optimize performance at different map scales.
-
 ## Environment Variables
 
 - `PORT` - Server port (default: 3001)


### PR DESCRIPTION
Models can not be configured for specific zoom levels.  The zoom level just informs the user on the nature of the underlying training set.  Useful for downstream model selection in the osmsat-server.